### PR TITLE
fixed the URLs in the page change functions in the js to match the re…

### DIFF
--- a/assets/index.js
+++ b/assets/index.js
@@ -34,7 +34,7 @@ function searchMovie() {
 
 
 function changePage() {
-  document.location.href = "https://skullkid4200.github.io/Atomic-Cats-Project-1/results";
+  document.location.href = "https://skullkid4200.github.io/Random-Similar-Movie-Generator/results";
 }
 
 

--- a/assets/results.js
+++ b/assets/results.js
@@ -77,7 +77,7 @@ function getSimilarMovies() {
 
 
 function returnHome() {
-  document.location.href = "https://skullkid4200.github.io/Atomic-Cats-Project-1/";
+  document.location.href = "https://skullkid4200.github.io/Random-Similar-Movie-Generator/";
 }
 
 


### PR DESCRIPTION
…pository name on github. kinda silly that changing the name of a repository changes the URLs (that makes sense, sure) and then any usage of those URLs in your code is nullified. maybe there's a way to avoid this? 